### PR TITLE
refactored css code book now and hotel details pages

### DIFF
--- a/src/pages/BookNow.jsx
+++ b/src/pages/BookNow.jsx
@@ -14,19 +14,19 @@ const BookingNow = () => {
   const navigate = useNavigate();
 
   return (
-    <Grid container spacing={2}>
+    <Grid container spacing={2} className='m-container'>
       <Grid
         size={{ xs: 12, sm: 12 }}
         sx={{ textAlign: 'center', justifyContent: 'center' }}
       >
-        <Typography variant="h5" color="primary.main" sx={{ mb: 2 }}>
+        <Typography variant="h5" color="primary.main" sx={{ m: 2 }}>
           Kindred Cottage
         </Typography>
         <RatingBadge rating={5} label="Excellent" reviews={650} />
       </Grid>
 
       <Grid size={{ xs: 12, sm: 12 }}>
-      <Typography variant="body1" sx={{ mb: 2 }}>
+      <Typography variant="body1" sx={{ mb: 2 }} align="justify">
           Kindred Cottage is a lovely home with waterfront to the channel
           leading into First Lake, Fulton Chain. Situated in the Hollywood
           Hills, a short drive into the village. The waterfront with private

--- a/src/pages/HotelDetailsPage.jsx
+++ b/src/pages/HotelDetailsPage.jsx
@@ -27,7 +27,7 @@ export default function HotelDetailsPage() {
   console.log(hotelDetails);
 
   return (
-    <Grid container spacing={2}>
+    <Grid container spacing={2} className='m-container'>
       <Grid size={{ xs: 12, sm: 12 }} sx={{ width: '100%' }}>
         <Typography variant="h5" color="primary.main" sx={{ mb: 2 }}>
           {hotelDetails?.name}
@@ -66,7 +66,7 @@ export default function HotelDetailsPage() {
             />
           </Box>
           <Box sx={{ width: { xs: '100%', sm: '100%', md: '60%' } }}>
-            <Typography variant="subtitle1">
+            <Typography variant="subtitle1" align="justify">
               {hotelDetails?.description_translations?.[0]?.description}
             </Typography>
           </Box>


### PR DESCRIPTION
**Margin added and text aligned as justified.**

**BookNow page:**
Before:
![BookNowBeforeDesktop](https://github.com/user-attachments/assets/cc7dd9ba-eb58-463a-90ae-4284c5edc533)
![BookNowBeforeMobile](https://github.com/user-attachments/assets/56674516-4f34-4c2a-a8d0-9f3d819a2f3f)
After:
![BookNowAfterDesktop](https://github.com/user-attachments/assets/f6b2afdc-76e0-4d36-8d16-655c820068b1)
![BookNowAfterMobile](https://github.com/user-attachments/assets/64743db3-434e-4145-b0dc-9b0a0ee3cf82)

**HotelDetails page:**
Before:
![HotelDetailsBeforeDesktop](https://github.com/user-attachments/assets/c1f59b65-4b11-4f56-b108-f64e6b79b5a5)
![HotelDetailsBeforeMobile](https://github.com/user-attachments/assets/28743625-ffab-4be1-8c64-a905919bc5b0)
After:
![HotelDetailsAfterMobile](https://github.com/user-attachments/assets/55e680a1-a4da-42a2-aad0-0d6038106cd1)


